### PR TITLE
修改数据库表

### DIFF
--- a/diagnosis/models.py
+++ b/diagnosis/models.py
@@ -1,5 +1,39 @@
 from django.db import models
-from patient_records.models import Patient, Doctor
+from patient_records.models import PatientInfo, Doctor
+
+class DiagResult(models.Model):
+    # 新诊断结果表（诊断结果包含多个标签如0123）
+    result_type = models.CharField(max_length=50, verbose_name='诊断结果标签')
+
+    patient = models.ForeignKey(PatientInfo, on_delete=models.CASCADE, related_name='diagnosis_results')
+
+    # 八种病的置信度
+    confidence_0 = models.FloatField(verbose_name='无外伤置信度', default=0.0)
+    confidence_1 = models.FloatField(verbose_name='腹盆腔或腹膜后积血/血肿置信度', default=0.0)
+    confidence_2 = models.FloatField(verbose_name='肝脏损伤置信度', default=0.0)
+    confidence_3 = models.FloatField(verbose_name='脾脏损伤置信度', default=0.0)
+    confidence_4 = models.FloatField(verbose_name='右肾损伤置信度', default=0.0)
+    confidence_5 = models.FloatField(verbose_name='左肾损伤置信度', default=0.0)
+    confidence_6 = models.FloatField(verbose_name='右肾上腺损伤置信度', default=0.0)
+    confidence_7 = models.FloatField(verbose_name='胰腺损伤置信度', default=0.0)
+
+    # 医学图像存储路径
+    image = models.ImageField(upload_to='ct_images/%Y/%m/%d/', verbose_name='CT图像')
+
+    created_at = models.DateTimeField(auto_now_add=True, verbose_name='诊断时间')
+    updated_at = models.DateTimeField(auto_now=True, verbose_name='更新时间')
+    created_by = models.ForeignKey(Doctor, on_delete=models.CASCADE, verbose_name='创建医生')
+
+    class Meta:
+        verbose_name = '诊断结果'
+        verbose_name_plural = '诊断结果'
+        ordering = ['-created_at']
+
+    def __str__(self):
+        return f"{self.patient.image_style} - {self.result_type} ({self.created_at.strftime('%Y-%m-%d %H:%M')})"
+
+
+
 
 # 诊断结果模型
 class DiagnosisResult(models.Model):
@@ -67,4 +101,5 @@ class DiagnosisResult(models.Model):
     @property
     def severe_probability(self):
         """返回重度肺炎概率的百分比形式（0-100）"""
+
         return self.probability_severe * 100 

--- a/diagnosis/models.py
+++ b/diagnosis/models.py
@@ -3,7 +3,7 @@ from patient_records.models import PatientInfo, Doctor
 
 class DiagResult(models.Model):
     # 新诊断结果表（诊断结果包含多个标签如0123）
-    result_type = models.CharField(max_length=50, verbose_name='诊断结果标签')
+    result_type = models.CharField(max_length=20, verbose_name='诊断结果标签')
 
     patient = models.ForeignKey(PatientInfo, on_delete=models.CASCADE, related_name='diagnosis_results')
 
@@ -103,3 +103,4 @@ class DiagnosisResult(models.Model):
         """返回重度肺炎概率的百分比形式（0-100）"""
 
         return self.probability_severe * 100 
+

--- a/patient_records/models.py
+++ b/patient_records/models.py
@@ -19,6 +19,27 @@ class Doctor(models.Model):
     def __str__(self):
         return self.full_name
 
+
+class PatientInfo(models.Model):
+    """!!!患者医学图像信息表!!!"""
+    
+    patient_id = models.BigAutoField(primary_key=True, verbose_name='患者ID')
+    image_style = models.CharField(max_length=30, verbose_name='医学图像类别')
+    image = models.ImageField(upload_to='ct_images/%Y/%m/%d/', verbose_name='医学图像')
+    created_at = models.DateTimeField(auto_now_add=True, verbose_name='创建时间')
+    updated_at = models.DateTimeField(auto_now=True, verbose_name='更新时间')
+    created_by = models.ForeignKey('Doctor', on_delete=models.CASCADE, verbose_name='创建人')
+
+    
+    class Meta:
+        db_table = 'patient'
+        verbose_name = '患者'
+        verbose_name_plural = '患者'
+        
+    def __str__(self):
+        return f"{self.patient_id} - {self.image_style}"
+
+
 class Patient(models.Model):
     """患者信息表"""
     GENDER_CHOICES = (


### PR DESCRIPTION
修改了patient_records和diagnosis应用下的model；


增加了两个新表，患者医学图像信息表PatientInfo和患者诊断结果表DiagResult。患者医学图像信息表中的image_style表示使用的是CT、MRI还是超声，image这个字段建议直接使用医学图像在本地的路由来表示。患者诊断结果表的result_type字段为字符串类型，患者诊断结果可以包含多种病症，如01234，每一种病症都有置信度


由于之前的表被多次引用，修改后可能出现bug，所以之前的表如果使用不到的话，最好别动
